### PR TITLE
Use the keyfile backend for the session snap

### DIFF
--- a/ubuntu-desktop-session/scripts/session-wrapper.sh
+++ b/ubuntu-desktop-session/scripts/session-wrapper.sh
@@ -9,6 +9,7 @@ if [ -f /snap/snapd/current/etc/profile.d/apps-bin-path.sh ]; then
 fi
 
 export XDG_CURRENT_DESKTOP=ubuntu:GNOME
+export GSETTINGS_BACKEND=keyfile
 
 dbus-update-activation-environment --systemd --all
 


### PR DESCRIPTION
Use the keyfile backend for the session snap, which is necessary for gsettings within the session.