### PR TITLE
Create XDG_RUNTIME_DIR on startup

### DIFF
--- a/ubuntu-desktop-session/scripts/run-session.sh
+++ b/ubuntu-desktop-session/scripts/run-session.sh
@@ -4,5 +4,8 @@
 mkdir -p /tmp/.X11-unix
 chmod 01777 /tmp/.X11-unix
 
+# Create the runtime directory
+mkdir -p --mode=700 $XDG_RUNTIME_DIR
+
 export GNOME_SHELL_SESSION_MODE=ubuntu
 exec /usr/bin/gnome-session --session=ubuntu


### PR DESCRIPTION
This fixes the session from failing to start due to not being able to create a file for ICE in this directory.