### PR TITLE
UCD-94: Add audio support for Core Desktop

### DIFF
--- a/ubuntu-desktop-session/scripts/run-session.sh
+++ b/ubuntu-desktop-session/scripts/run-session.sh
@@ -8,4 +8,5 @@ chmod 01777 /tmp/.X11-unix
 mkdir -p --mode=700 $XDG_RUNTIME_DIR
 
 export GNOME_SHELL_SESSION_MODE=ubuntu
+export PULSE_SERVER=unix:/run/user/`id -u`/pulse/native
 exec /usr/bin/gnome-session --session=ubuntu

--- a/ubuntu-desktop-session/snap/snapcraft.yaml
+++ b/ubuntu-desktop-session/snap/snapcraft.yaml
@@ -28,6 +28,7 @@ apps:
       - x11
     plugs:
       - audio-playback
+      - audio-record
 
   gnome-terminal-server:
     command: run.sh /usr/libexec/gnome-terminal-server
@@ -63,6 +64,7 @@ apps:
 
 plugs:
   audio-playback: null
+  audio-record: null
   desktop-launch: null
   hardware-observe: null
   home: null

--- a/ubuntu-desktop-session/snap/snapcraft.yaml
+++ b/ubuntu-desktop-session/snap/snapcraft.yaml
@@ -26,6 +26,8 @@ apps:
     slots:
       - wayland
       - x11
+    plugs:
+      - audio-playback
 
   gnome-terminal-server:
     command: run.sh /usr/libexec/gnome-terminal-server
@@ -60,6 +62,7 @@ apps:
         - dbus-freedesktop-impl-portal-gtk
 
 plugs:
+  audio-playback: null
   desktop-launch: null
   hardware-observe: null
   home: null


### PR DESCRIPTION
This is one of the three MRs required for adding audio support to Core Desktop. This one adds the required plugs to the session and defines the PULSE_SERVER environment variable to make it point to the right path.