### PR TITLE
ci: use newer runner image, and pack artifact as sparse .tar.gz

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -28,4 +28,4 @@ jobs:
           name: image
           path: |
             README.md
-            *.img.gz
+            *.tar.gz

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   image:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 EXTRA_SNAPS =
 ALL_SNAPS = $(EXTRA_SNAPS) firefox gnome-calculator gnome-characters gnome-clocks gnome-font-viewer gnome-weather
 
-all: pc.img.gz
+all: pc.tar.gz
 
 pc.img: ubuntu-core-desktop.model $(EXTRA_SNAPS)
 	rm -rf img/
-	ubuntu-image snap --output-dir img --image-size 8G \
+	ubuntu-image snap --output-dir img --image-size 12G \
 	  $(foreach snap,$(ALL_SNAPS),--snap $(snap)) $<
 	mv img/pc.img .
 
@@ -16,7 +16,7 @@ ubuntu-core-desktop.model: ubuntu-core-desktop.json
 	snap sign $< > $@
 endif
 
-%.img.gz: %.img
-	gzip --keep $<
+%.tar.gz: %.img
+	tar czSf $@ $<
 
 .PHONY: all


### PR DESCRIPTION
The latest ubuntu-image snap seems to be incompatible with the Ubuntu 20.04 runner image we're using, so try bumping that to `ubuntu-latest`.

Also bump the image size up to 12 GB, and pack it as a sparse .tar.gz file. The images were packed sparse when we were using xz, but gzip alone doesn't support that.