### PR TITLE
model: switch models over to being signed by Canonical brand account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,11 @@ ALL_SNAPS = $(EXTRA_SNAPS) firefox gnome-calculator gnome-characters gnome-clock
 
 all: pc.tar.gz
 
-pc.img: ubuntu-core-desktop.model $(EXTRA_SNAPS)
+pc.img: ubuntu-core-desktop-22-amd64.model $(EXTRA_SNAPS)
 	rm -rf img/
 	ubuntu-image snap --output-dir img --image-size 12G \
 	  $(foreach snap,$(ALL_SNAPS),--snap $(snap)) $<
 	mv img/pc.img .
-
-# Rules to resign assertions: only enable if we have a default signing key
-ifneq (,$(findstring default,$(shell snap keys)))
-ubuntu-core-desktop.model: ubuntu-core-desktop.json
-	snap sign $< > $@
-endif
 
 %.tar.gz: %.img
 	tar czSf $@ $<

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,41 @@
+# Core Desktop Models
+
+The model definition is a signed assertion that describes the snaps
+that make up an Ubuntu Core Desktop system. The format is described here:
+
+https://ubuntu.com/core/docs/reference/assertions/model
+
+We currently have two model definitions:
+
+* `ubuntu-core-desktop-22-amd64`
+* `ubuntu-core-desktop-22-amd64-dangerous`
+
+They are identical except for the `grade` property: the regular model
+requires all snaps in the seed be signed and published by the store,
+while the dangerous model allows us to build with unpublished snaps.
+
+The dangerous model is primarily intended to allow testing of modified
+snaps prior to publishing them to the store.
+
+## Modifying the models
+
+To modify the list of snaps in the model, edit the model's json
+file. In addition, remember to make the following changes:
+
+1. update the `timestamp` property to the current time. The command
+   `date -u --iso=seconds` will output it in the required format.
+2. increment the `revision` property. The default value for `revision`
+   is `0`, so if the property doesn't currently exist set it to `1`.
+
+Then make the equivalent changes to the dangerous model.
+
+Next, it is necessary to get the model signed. The Canonical brand
+account key is controlled by IS, so this is done by filing an RT
+request with the new json files attached.
+
+When the new models are signed, they can be committed back to this
+repository.
+
+In addition to this, Foundations has asked us to also add a copy of
+the model to the
+[`snapcore/models`](https://github.com/snapcore/models) repository.

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -1,10 +1,10 @@
 {
     "type": "model",
-    "authority-id": "PhMj3TyWXsKJda10Fah6d6selJIw1xCI",
-    "brand-id": "PhMj3TyWXsKJda10Fah6d6selJIw1xCI",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
     "series": "16",
-    "model": "ubuntu-core-desktop-22-amd64",
-    "display-name":"Ubuntu Core Desktop 22 (amd64)",
+    "model": "ubuntu-core-desktop-22-amd64-dangerous",
+    "display-name":"Ubuntu Core Desktop 22 (amd64) (dangerous)",
     "architecture": "amd64",
     "grade": "dangerous",
     "base": "core22-desktop",
@@ -182,5 +182,5 @@
             "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8"
         }
     ],
-    "timestamp": "2023-06-16T13:05:25+08:00"
+    "timestamp": "2023-06-20T07:40:40+00:00"
 }

--- a/ubuntu-core-desktop-22-amd64-dangerous.model
+++ b/ubuntu-core-desktop-22-amd64-dangerous.model
@@ -1,0 +1,168 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-desktop-22-amd64-dangerous
+architecture: amd64
+base: core22-desktop
+display-name: Ubuntu Core Desktop 22 (amd64) (dangerous)
+grade: dangerous
+snaps:
+  -
+    default-channel: latest/edge
+    id: mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy
+    name: pc-desktop
+    type: gadget
+  -
+    default-channel: 22/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge/ubuntu-core-desktop
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: latest/edge
+    id: qRMmQqNDz8kRUTqFIgqk2RzNNoC7jUZ6
+    name: core22-desktop
+    type: base
+  -
+    default-channel: latest/edge
+    id: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN
+    name: ubuntu-desktop-session
+    type: app
+  -
+    default-channel: latest/stable
+    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    name: core22
+    type: base
+  -
+    default-channel: 22/stable
+    id: RmBXKl6HO6YOC2DE4G2q1JzWImC04EUy
+    name: network-manager
+    type: app
+  -
+    default-channel: latest/stable
+    id: EISPgh06mRh1vordZY9OZ34QHdd7OrdR
+    name: bare
+    type: base
+  -
+    default-channel: latest/stable
+    id: jZLfBRzf1cYlYysIjD2bwSzNtngY0qit
+    name: gtk-common-themes
+    type: app
+  -
+    default-channel: latest/stable
+    id: lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3
+    name: gnome-42-2204
+    type: app
+  -
+    default-channel: latest/stable
+    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
+    name: core20
+    type: base
+  -
+    default-channel: latest/stable
+    id: m1eQacDdXCthEwWQrESei3Zao3d5gfJF
+    name: cups
+    type: app
+  -
+    default-channel: latest/stable
+    id: dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll
+    name: avahi
+    type: app
+  -
+    default-channel: 22/stable
+    id: JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS
+    name: bluez
+    type: app
+  -
+    default-channel: latest/stable
+    id: wWtGKn0vLvagfg975tebXfBARLUvU3G7
+    name: eog
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: EDFg87ESUg9sAIlm0Vm5Wmr0LjiEonSm
+    name: evince
+    presence: optional
+    type: app
+  -
+    default-channel: latest/candidate/core22
+    id: 3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk
+    name: firefox
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: J8OcDPQ0JM8dbvk29HRqpWVI9kBw0atG
+    name: gnome-calculator
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: qJcS3UjpF9AMJKWAiKwA5EWbm0y6Uduw
+    name: gnome-characters
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: 8NtSF2nXW6krsxbXBYydy1j985k6ZsVK
+    name: gnome-clocks
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: BzJuWXmCIpyjUKotXPWU2psnl8gEh4hm
+    name: gnome-font-viewer
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: kIMfmZTJspWa8vtfbgU3W9Nbv4V5Qgmh
+    name: gnome-logs
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: PZj2sEabMQrVUV1HKZmmmXSk3E6wKC9i
+    name: gnome-text-editor
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: LhzK7p8214jufMYx1kz43QkWhFnOKdbr
+    name: gnome-weather
+    presence: optional
+    type: app
+  -
+    default-channel: latest/stable
+    id: J60k4JY0HppjwOjW8dZdYc8obXKxujRu
+    name: lxd
+    type: app
+  -
+    default-channel: preview/edge
+    id: gjf3IPXoRiipCu9K0kVu52f0H56fIksg
+    name: snap-store
+    type: app
+  -
+    default-channel: latest/stable
+    id: JMjaFobGn56fh1HepiaGuCxQgbWYnHc8
+    name: workshops
+    type: app
+timestamp: 2023-06-20T07:40:40+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCZJGcvwAKCRDgT5vottzAEuCZD/9cfEP3vAxdThvyK46Go52c/yRoRe+vSLf0
+nf9w9z0BSFOEnhynzh5rG9w0V3qkQfhWiFN6CCOLLAmkZnrL24IMVeeSls4WNEbkfJzRWMwt5Ui3
+5jOQqu82/kkvuazkKJCFI0J+Lxqngh1DhE2Dr2vR3T04ZeTVzHAmvLLCfK/Tnghm56TI6JUywLhl
++JtVTsWX0yO3KPPh4AYb1UltDOuOWrzT6zC1t/NwLEAFKvQ/LdeJ/kVeKmDFFUX3AezuxvOQNdO6
+92NyCSxrNCFPjVSZbPyAN0a3xWLSU5NoxBSHxOzir0qIj+Wa6QZhpQIDA0GJD4KKpZLVyX/S8T10
+RW2w3s7ZvkFxXk+S899a5shhtk1yiW3V/jbW2ez1l9S1D99Nay4RIaQkTS5zG5kcHu3/GLN8urOZ
+cy2SDwoigG7xjZUCae81RhzFvK7BfOd/6LGpIrU/+JMchVZgulFPgp2z/On2Rbd0pzqrc/KeWONI
+AsvoVQpT8/pacrpBlBvS+5RXxqIuV7+QuuaInrBe7+qHoDfdYFewFKqeHqR5sUkjMS01Y/Sjw+Wo
+NAb3yUe2vZPRJFxPO2bSNaL8o7SKB4wqqybEpLua1SnYR+OlaJxs981p/DJoeFwCajdXJ1RkHBrW
+c6ACaHQtT5Gl5qVrJJzOHM2P9dtybeS+NE+WtTKBbg==

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -1,0 +1,186 @@
+{
+    "type": "model",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "series": "16",
+    "model": "ubuntu-core-desktop-22-amd64",
+    "display-name":"Ubuntu Core Desktop 22 (amd64)",
+    "architecture": "amd64",
+    "grade": "signed",
+    "base": "core22-desktop",
+    "snaps": [
+        {
+            "name": "pc-desktop",
+            "default-channel": "latest/edge",
+            "type": "gadget",
+            "id": "mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy"
+        },
+        {
+            "name": "pc-kernel",
+            "default-channel": "22/stable",
+            "type": "kernel",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "snapd",
+            "default-channel": "latest/edge/ubuntu-core-desktop",
+            "type": "snapd",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "core22-desktop",
+            "default-channel": "latest/edge",
+            "type": "base",
+            "id": "qRMmQqNDz8kRUTqFIgqk2RzNNoC7jUZ6"
+        },
+        {
+            "name": "ubuntu-desktop-session",
+            "default-channel": "latest/edge",
+            "type": "app",
+            "id": "LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN"
+        },
+        {
+            "name": "core22",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+        },
+        {
+            "name": "network-manager",
+            "default-channel": "22/stable",
+            "type": "app",
+            "id": "RmBXKl6HO6YOC2DE4G2q1JzWImC04EUy"
+        },
+        {
+            "name": "bare",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "EISPgh06mRh1vordZY9OZ34QHdd7OrdR"
+        },
+        {
+            "name": "gtk-common-themes",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "jZLfBRzf1cYlYysIjD2bwSzNtngY0qit"
+        },
+        {
+            "name": "gnome-42-2204",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3"
+        },
+        {
+            "name": "core20",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q"
+        },
+        {
+            "name": "cups",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "m1eQacDdXCthEwWQrESei3Zao3d5gfJF"
+        },
+        {
+            "name": "avahi",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll"
+        },
+        {
+            "name": "bluez",
+            "default-channel": "22/stable",
+            "type": "app",
+            "id": "JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS"
+        },
+        {
+            "name": "eog",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "wWtGKn0vLvagfg975tebXfBARLUvU3G7",
+            "presence": "optional"
+        },
+        {
+            "name": "evince",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "EDFg87ESUg9sAIlm0Vm5Wmr0LjiEonSm",
+            "presence": "optional"
+        },
+        {
+            "name": "firefox",
+            "default-channel": "latest/candidate/core22",
+            "type": "app",
+            "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk",
+            "presence": "optional"
+        },
+        {
+            "name": "gnome-calculator",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "J8OcDPQ0JM8dbvk29HRqpWVI9kBw0atG",
+            "presence": "optional"
+        },
+        {
+            "name": "gnome-characters",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "qJcS3UjpF9AMJKWAiKwA5EWbm0y6Uduw",
+            "presence": "optional"
+        },
+        {
+            "name": "gnome-clocks",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "8NtSF2nXW6krsxbXBYydy1j985k6ZsVK",
+            "presence": "optional"
+        },
+        {
+            "name": "gnome-font-viewer",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "BzJuWXmCIpyjUKotXPWU2psnl8gEh4hm",
+            "presence": "optional"
+        },
+        {
+            "name": "gnome-logs",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "kIMfmZTJspWa8vtfbgU3W9Nbv4V5Qgmh",
+            "presence": "optional"
+        },
+        {
+            "name": "gnome-text-editor",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "PZj2sEabMQrVUV1HKZmmmXSk3E6wKC9i",
+            "presence": "optional"
+        },
+        {
+            "name": "gnome-weather",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "LhzK7p8214jufMYx1kz43QkWhFnOKdbr",
+            "presence": "optional"
+        },
+        {
+            "name": "lxd",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "J60k4JY0HppjwOjW8dZdYc8obXKxujRu"
+        },
+        {
+            "name": "snap-store",
+            "default-channel": "preview/edge",
+            "type": "app",
+            "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
+        },
+        {
+            "name": "workshops",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8"
+        }
+    ],
+    "timestamp": "2023-06-20T07:40:40+00:00"
+}

--- a/ubuntu-core-desktop-22-amd64.model
+++ b/ubuntu-core-desktop-22-amd64.model
@@ -1,12 +1,12 @@
 type: model
-authority-id: PhMj3TyWXsKJda10Fah6d6selJIw1xCI
+authority-id: canonical
 series: 16
-brand-id: PhMj3TyWXsKJda10Fah6d6selJIw1xCI
+brand-id: canonical
 model: ubuntu-core-desktop-22-amd64
 architecture: amd64
 base: core22-desktop
 display-name: Ubuntu Core Desktop 22 (amd64)
-grade: dangerous
+grade: signed
 snaps:
   -
     default-channel: latest/edge
@@ -153,16 +153,16 @@ snaps:
     id: JMjaFobGn56fh1HepiaGuCxQgbWYnHc8
     name: workshops
     type: app
-timestamp: 2023-06-16T13:05:25+08:00
-sign-key-sha3-384: DcLw22apMVMI7ANPT9JYc15zYZu4u7LlKuuMtaJCRjaXnS0KaAWBh-1a-_ES2Xam
+timestamp: 2023-06-20T07:40:40+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBcwQAAQoAHRYhBF7Jk7LWvjDgjaKu8q/DToINRsqGBQJki+2tAAoJEK/DToINRsqGWcMP/1uP
-+mmbOKXIcttl1b2IRuFyuj4w8xLwZaQQhaGIXW5Pgk2vAqG8te75R4h99BYkYUbNhKUPicG0Mm38
-Jus9coDZf94f80/CKs0xGHA0AG+YVkgCsqaFFtWfuxO39MBIcZEBTjYRQaU2hDuVhIVi2RRfNa7d
-Xzgl+POyxnt35vPkyxJkkleNHSnZa7SM17fd1tfrxWoaHqjQwuHxGxBM0HHWkmgK3ReQBVYSVxn/
-yb5PBB+O0j65xzya6AZDFU1pl5QV8sX+yCLbdoqZc/DK3zz2j0T0QCDBQB58tD9T+k0jcE4Q+Wbs
-24Bo9ReqgK8Tg4EKw7z+uVg9ZugFi+/KaPisIQt77TkRTkXq9ndhFWxr/KMP9zxg18qASPa97R40
-rc079a1xqq4eHqyEAfejvzYBM0Utt1twfa58Fd+J0uumyR4rHJP+9aoBWUfUP2ToMyw5Eu2NB0OO
-K/Vs9vVdw4/KtB4DzFHqDERDmYJbE0W0WN1EDbfgbdujdCzc3Q4akZVkW3x35Npzl6RwjFcV32Cl
-60hkgSVLYfODOxGhRxi/SWOmMyNPSr/V5vVZmqkS01zpxWQBq+KJ7HzkLaMukE+1DRz3s4XGH6nE
-d79TFihFNE5JyVBynWMMNhEMAWq3/ydjadzVrp4rPgavneNcCB5p5v2noMMnphD5/IfLf8kD
+AcLBXAQAAQoABgUCZJGczQAKCRDgT5vottzAEi3mEACRRrRYfjMrNrHw15n6MlRey3eafGz5dZ6K
+yOK2NNpeTWrbR1oX3U8Ck383VJWVejuKVvWoTNQBvbyt17sZ0FYjU3lsrdsXU2pHoKl5/V33kWO1
+jCcCMuGbLrU3BiU8dT/4Tjaopz0QRHQ2X3fc220VuC8f5czFUEaU8ybrZWy/59H4AdFiXXopEicd
+88ORfo/OKUNMZCu7ap/5s0Si/er5+VreLLYV0YHJC5QofXXs56LxshvUnC0vODoJgzUtqL7ubeQH
+rrAqavo9EDb8kJKEUooIDsK78Btf3BinsS79nT6N76k2k0IKGsLqIXpP4DQYE/oC2RHvNBrg/Lmy
++Xqs9tRCxC2cV1/3tYojaVE+BQEUD8XXHiGhR4LfJyEqIAhMfVrryVO/yJaUMznnDDYuNBCOYx7X
+JgKbQ5fqjjv/uV0vgpSioQgihttpwVUhowLuC68/lUyBCalUXvdQ4SZrES5KIzvn8G/E2G3UCE+K
+466VR7EiwZPWD3b+xKe+fBjZaTdQ2t1NN9MDIm8lxHo7w0QZofP4R7TKQaQVYu2+8gHZc7ar0ZE4
+3MigjvkJ/VxQSu8mvSz9lAYNhp0JTs8rCRX0cxuezFrjppAegNevxbUlZzsf0OytwB7bNkCFl+6e
+z1+4IEASWs3jwCHEzJewUNy6t0Bpf12lRVeOjJ+ocQ==


### PR DESCRIPTION
This replaces the model signed with my own personal account key with ones signed with the Canonical brand account key. I've also switched the main model over to use `grade: signed`, since we're now using published snaps everywhere. I got a second `grade: dangerous` model signed that we can continue to test out unpublished snaps.