### PR TITLE
Update channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ pc.img: ubuntu-core-desktop-22-amd64.model $(EXTRA_SNAPS)
 	  $(foreach snap,$(ALL_SNAPS),--snap $(snap)) $<
 	mv img/pc.img .
 
+pc-dangerous.img: ubuntu-core-desktop-22-amd64-dangerous.model $(EXTRA_SNAPS)
+	rm -rf dangerous/
+	ubuntu-image snap --output-dir dangerous --image-size 12G \
+	  $(foreach snap,$(ALL_SNAPS),--snap $(snap)) $<
+	mv dangerous/pc.img pc-dangerous.img
+
 %.tar.gz: %.img
 	tar czSf $@ $<
 

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -72,12 +72,6 @@
             "id": "lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3"
         },
         {
-            "name": "core20",
-            "default-channel": "latest/stable",
-            "type": "base",
-            "id": "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q"
-        },
-        {
             "name": "cups",
             "default-channel": "latest/stable",
             "type": "app",
@@ -91,7 +85,7 @@
         },
         {
             "name": "avahi",
-            "default-channel": "latest/stable",
+            "default-channel": "22/stable",
             "type": "app",
             "id": "dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll"
         },
@@ -117,7 +111,7 @@
         },
         {
             "name": "firefox",
-            "default-channel": "latest/stable/ubuntu-23.10",
+            "default-channel": "latest/stable",
             "type": "app",
             "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk",
             "presence": "optional"

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -13,7 +13,7 @@
     "snaps": [
         {
             "name": "pc-desktop",
-            "default-channel": "latest/edge",
+            "default-channel": "22/stable",
             "type": "gadget",
             "id": "mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy"
         },
@@ -31,13 +31,13 @@
         },
         {
             "name": "core22-desktop",
-            "default-channel": "latest/edge",
+            "default-channel": "latest/stable",
             "type": "base",
             "id": "qRMmQqNDz8kRUTqFIgqk2RzNNoC7jUZ6"
         },
         {
             "name": "ubuntu-desktop-session",
-            "default-channel": "latest/edge",
+            "default-channel": "latest/stable",
             "type": "app",
             "id": "LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN"
         },
@@ -185,7 +185,7 @@
         },
         {
             "name": "snap-store",
-            "default-channel": "preview/edge",
+            "default-channel": "preview/edge/ubuntu-23.10",
             "type": "app",
             "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
         },

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -194,6 +194,13 @@
             "default-channel": "latest/stable",
             "type": "app",
             "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8"
+        },
+        {
+            "name": "gnome-system-monitor",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "9BTClmjz31r0UltmbJ5nnGe0Xm1AzfMp",
+            "presence": "optional"
         }
     ]
 }

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -117,7 +117,7 @@
         },
         {
             "name": "firefox",
-            "default-channel": "latest/candidate/core22",
+            "default-channel": "latest/stable/ubuntu-23.10",
             "type": "app",
             "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk",
             "presence": "optional"

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -185,7 +185,7 @@
         },
         {
             "name": "snap-store",
-            "default-channel": "preview/edge/ubuntu-23.10",
+            "default-channel": "latest/stable/ubuntu-23.10",
             "type": "app",
             "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
         },

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -9,6 +9,7 @@
     "revision": "3",
     "timestamp": "2023-08-25T18:50:16+00:00",
     "grade": "dangerous",
+    "storage-safety": "prefer-encrypted",
     "base": "core22-desktop",
     "snaps": [
         {

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -6,8 +6,8 @@
     "model": "ubuntu-core-desktop-22-amd64-dangerous",
     "display-name":"Ubuntu Core Desktop 22 (amd64) (dangerous)",
     "architecture": "amd64",
-    "revision": "2",
-    "timestamp": "2023-08-02T04:56:00+00:00",
+    "revision": "3",
+    "timestamp": "2023-08-25T18:50:16+00:00",
     "grade": "dangerous",
     "base": "core22-desktop",
     "snaps": [

--- a/ubuntu-core-desktop-22-amd64-dangerous.model
+++ b/ubuntu-core-desktop-22-amd64-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 2
+revision: 3
 series: 16
 brand-id: canonical
 model: ubuntu-core-desktop-22-amd64-dangerous
@@ -10,7 +10,7 @@ display-name: Ubuntu Core Desktop 22 (amd64) (dangerous)
 grade: dangerous
 snaps:
   -
-    default-channel: latest/edge
+    default-channel: 22/stable
     id: mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy
     name: pc-desktop
     type: gadget
@@ -25,12 +25,12 @@ snaps:
     name: snapd
     type: snapd
   -
-    default-channel: latest/edge
+    default-channel: latest/stable
     id: qRMmQqNDz8kRUTqFIgqk2RzNNoC7jUZ6
     name: core22-desktop
     type: base
   -
-    default-channel: latest/edge
+    default-channel: latest/stable
     id: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN
     name: ubuntu-desktop-session
     type: app
@@ -61,11 +61,6 @@ snaps:
     type: app
   -
     default-channel: latest/stable
-    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
-    name: core20
-    type: base
-  -
-    default-channel: latest/stable
     id: m1eQacDdXCthEwWQrESei3Zao3d5gfJF
     name: cups
     type: app
@@ -75,7 +70,7 @@ snaps:
     name: ipp-usb
     type: app
   -
-    default-channel: latest/stable
+    default-channel: 22/stable
     id: dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll
     name: avahi
     type: app
@@ -97,7 +92,7 @@ snaps:
     presence: optional
     type: app
   -
-    default-channel: latest/candidate/core22
+    default-channel: latest/stable
     id: 3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk
     name: firefox
     presence: optional
@@ -155,7 +150,7 @@ snaps:
     name: snapd-desktop-integration
     type: app
   -
-    default-channel: preview/edge
+    default-channel: latest/stable/ubuntu-23.10
     id: gjf3IPXoRiipCu9K0kVu52f0H56fIksg
     name: snap-store
     type: app
@@ -164,16 +159,23 @@ snaps:
     id: JMjaFobGn56fh1HepiaGuCxQgbWYnHc8
     name: workshops
     type: app
-timestamp: 2023-08-02T04:56:00+00:00
+  -
+    default-channel: latest/stable
+    id: 9BTClmjz31r0UltmbJ5nnGe0Xm1AzfMp
+    name: gnome-system-monitor
+    presence: optional
+    type: app
+storage-safety: prefer-encrypted
+timestamp: 2023-08-25T18:50:16+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZNCGFgAKCRDgT5vottzAEsRyEACxApkkIKb+w9PNqTOGiPdRXAFtw2OUSvMI
-ChjO2lQlODA4an8qhtVzYC68Ui4AFoUV9GFcksA41ckhgas1mpU1oTFNc/sQdGI6ixoXvpGMUVxD
-vuIY+Ty9QOVoNfR2I7jThbcLOdojhDt8fudZ7AH7eWCk0GGFXkCtt8OPBdKy3bnc0lxI/07IAF92
-OK85i4Z4D44MChql/eJ1Myifuajc6WQnV/uAHvTwl4G19AExwJS9Cs5TbtQJo38b8sRzTw2nr0Rg
-lsANHZkIoH9UN17ZvSYkbdEl9TleVteNmm2AJuOQq8vebeG9QYH+33lZ5OXNdtDl+T9aAoD7BNtI
-V+1nqJLoVmMdoX2VMcSmukN5P7cpPZJ8HjiSFkbJec3/tggT4BGgOMXNBjJrfS61lPVzI0esbpYX
-ORin9194uOJRxUNDNgJktaA6UGiH8jwNrPYAvGZuLb6YsXAyURFjNH17YguJl81Oq2sssT7wqyld
-wOXDvQxMY+Sj1W8nF8qiKTmmEbygdqppfWWoq5yer1K7OgaTQpWsdIYX2GXH5vHIgci9ngagi1Ll
-KaS82Mawsz9+zpFS25q8vwrk8C1DSQPUleM0F4zGOlgkkC47hC638YS0fQ5/+n6rI4R0FoMkYx9k
-36OCn4M+7jDbymCcvtE+yjpXTsPZdAX8Q2Ftq48Y1Q==
+AcLBXAQAAQoABgUCZQCodgAKCRDgT5vottzAEuLnD/0YIute64cbdKOf91e68H2FKF1SGZpORhyl
+Zu9gwD6OM5jUq3qCarqSoEOw4krA3ZpLfSD0E8l90xD9/f9j7WFiPZgdG51Ga86Z9CAHzDpiuWmc
+p3X2LlBBFUEeY1k97/8f+mj2OzD6L97BIxobfUQvb8l2m1oE6useSan1KX7yoxWL35ubM9lg3ujx
+AMjFfJNafIhirYQT0wpCj3rI8a/qgbuChKC1jOS0sP2b7u0ntPcJ3rsT21gfXmqGx0MbFmI1BlgV
+ejrfDINhtXD58nJjtwx8O2hepda3TTKvLZZkOZZoaR4crf4o9ULNjIzsbKJ08v1XsgWU+upiNekp
+1nJo7GK/zK9vi85eI+zg/7pfByXZvwwIZRFkIqaNRvHgYytXjnvE5fvSoNeEq26Yb4Guf7+U5E41
+AKVs8/cNrznTz0dGGwqzmimTetb0XvWgjxtXOdn5BqG/iPAaD7EcCB+EMbffvOyIiUEwtenLTE5V
+C4rjOH9IEHMKHDPiD3N4+yctNmhvyXgTty8m1sqgcV/R8BA4upyo0K2uxvNbttWdO2xzhxO/seZO
+zh8uVpiAeAGMu977+ryjK7XoE/lkfvf4klECtLVrsf0o2eoncPKuQeyV1qWB/9yTgjY+RIL46AW5
+hedwIPZMoJt/h2KYQNKhejS0wVr8c8OoffRrc4Dddg==

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -72,12 +72,6 @@
             "id": "lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3"
         },
         {
-            "name": "core20",
-            "default-channel": "latest/stable",
-            "type": "base",
-            "id": "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q"
-        },
-        {
             "name": "cups",
             "default-channel": "latest/stable",
             "type": "app",
@@ -91,7 +85,7 @@
         },
         {
             "name": "avahi",
-            "default-channel": "latest/stable",
+            "default-channel": "22/stable",
             "type": "app",
             "id": "dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll"
         },
@@ -117,7 +111,7 @@
         },
         {
             "name": "firefox",
-            "default-channel": "latest/stable/ubuntu-23.10",
+            "default-channel": "latest/stable",
             "type": "app",
             "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk",
             "presence": "optional"

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -13,7 +13,7 @@
     "snaps": [
         {
             "name": "pc-desktop",
-            "default-channel": "latest/edge",
+            "default-channel": "22/stable",
             "type": "gadget",
             "id": "mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy"
         },
@@ -31,13 +31,13 @@
         },
         {
             "name": "core22-desktop",
-            "default-channel": "latest/edge",
+            "default-channel": "latest/stable",
             "type": "base",
             "id": "qRMmQqNDz8kRUTqFIgqk2RzNNoC7jUZ6"
         },
         {
             "name": "ubuntu-desktop-session",
-            "default-channel": "latest/edge",
+            "default-channel": "latest/stable",
             "type": "app",
             "id": "LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN"
         },
@@ -185,7 +185,7 @@
         },
         {
             "name": "snap-store",
-            "default-channel": "preview/edge",
+            "default-channel": "preview/edge/ubuntu-23.10",
             "type": "app",
             "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
         },

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -194,6 +194,13 @@
             "default-channel": "latest/stable",
             "type": "app",
             "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8"
+        },
+        {
+            "name": "gnome-system-monitor",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "9BTClmjz31r0UltmbJ5nnGe0Xm1AzfMp",
+            "presence": "optional"
         }
     ]
 }

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -117,7 +117,7 @@
         },
         {
             "name": "firefox",
-            "default-channel": "latest/candidate/core22",
+            "default-channel": "latest/stable/ubuntu-23.10",
             "type": "app",
             "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk",
             "presence": "optional"

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -9,6 +9,7 @@
     "revision": "3",
     "timestamp": "2023-08-25T18:50:16+00:00",
     "grade": "signed",
+    "storage-safety": "prefer-encrypted",
     "base": "core22-desktop",
     "snaps": [
         {

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -185,7 +185,7 @@
         },
         {
             "name": "snap-store",
-            "default-channel": "preview/edge/ubuntu-23.10",
+            "default-channel": "latest/stable/ubuntu-23.10",
             "type": "app",
             "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
         },

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -6,8 +6,8 @@
     "model": "ubuntu-core-desktop-22-amd64",
     "display-name":"Ubuntu Core Desktop 22 (amd64)",
     "architecture": "amd64",
-    "revision": "2",
-    "timestamp": "2023-08-02T04:56:00+00:00",
+    "revision": "3",
+    "timestamp": "2023-08-25T18:50:16+00:00",
     "grade": "signed",
     "base": "core22-desktop",
     "snaps": [

--- a/ubuntu-core-desktop-22-amd64.model
+++ b/ubuntu-core-desktop-22-amd64.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 2
+revision: 3
 series: 16
 brand-id: canonical
 model: ubuntu-core-desktop-22-amd64
@@ -10,7 +10,7 @@ display-name: Ubuntu Core Desktop 22 (amd64)
 grade: signed
 snaps:
   -
-    default-channel: latest/edge
+    default-channel: 22/stable
     id: mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy
     name: pc-desktop
     type: gadget
@@ -25,12 +25,12 @@ snaps:
     name: snapd
     type: snapd
   -
-    default-channel: latest/edge
+    default-channel: latest/stable
     id: qRMmQqNDz8kRUTqFIgqk2RzNNoC7jUZ6
     name: core22-desktop
     type: base
   -
-    default-channel: latest/edge
+    default-channel: latest/stable
     id: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN
     name: ubuntu-desktop-session
     type: app
@@ -61,11 +61,6 @@ snaps:
     type: app
   -
     default-channel: latest/stable
-    id: DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q
-    name: core20
-    type: base
-  -
-    default-channel: latest/stable
     id: m1eQacDdXCthEwWQrESei3Zao3d5gfJF
     name: cups
     type: app
@@ -75,7 +70,7 @@ snaps:
     name: ipp-usb
     type: app
   -
-    default-channel: latest/stable
+    default-channel: 22/stable
     id: dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll
     name: avahi
     type: app
@@ -97,7 +92,7 @@ snaps:
     presence: optional
     type: app
   -
-    default-channel: latest/candidate/core22
+    default-channel: latest/stable
     id: 3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk
     name: firefox
     presence: optional
@@ -155,7 +150,7 @@ snaps:
     name: snapd-desktop-integration
     type: app
   -
-    default-channel: preview/edge
+    default-channel: latest/stable/ubuntu-23.10
     id: gjf3IPXoRiipCu9K0kVu52f0H56fIksg
     name: snap-store
     type: app
@@ -164,16 +159,23 @@ snaps:
     id: JMjaFobGn56fh1HepiaGuCxQgbWYnHc8
     name: workshops
     type: app
-timestamp: 2023-08-02T04:56:00+00:00
+  -
+    default-channel: latest/stable
+    id: 9BTClmjz31r0UltmbJ5nnGe0Xm1AzfMp
+    name: gnome-system-monitor
+    presence: optional
+    type: app
+storage-safety: prefer-encrypted
+timestamp: 2023-08-25T18:50:16+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZNCGHwAKCRDgT5vottzAEmF9D/9XhVmpShjc8nbausGIvixN4ElePwBD8E4+
-jsxCMnmkyMgHVgmyy4ENLLAhGKmarsj7iBYvF/HzUsFKQ6YWFRrk5gkCuhitJoxVL6jxnilhX6zG
-E1oHzopd+ak3T/YLRT5V9P/II6NOImCkuYivvKQGX0GZL88YD3Wv9MyUnyZbotdZpCY7yo2UB/G0
-tTNUqlYCQffe8UB88gj7EKWWR5N/fLamzEOCtOfGJqFvTeKXMjJrPRIckQrCpR3hhhtHWY5CDYa+
-rKIVbDFsgTq6mfAyFvP9fngZTgC3NYkj9Evi/paEgZEj8iUelrFOH2ikvt4cAkC7GKqfYflKLEf3
-C6J9Azs8IgWmTgSmkwwqt+m48xHxfTP3sThPN4SNoH7FFx/jpJKkwkg9OFhDSoGJgonCUmoFSWvH
-j11AbyQlheZ3D0+cJJo9KUrFjH5bXrqCqa/8fgjiJqNL7Uw8ZHCBhY2okwEYDGp0JXJjmPLJU/gJ
-hQK6+A/HqVp39UvWDIchSggjRKsM/zQD44jhAxuyvPEr/tHoZr6/qFKOYbDyaxe7QE2poG8tKnMt
-AGCDgPEJ2ykXHWl6R+1TTOowpBg2duKfGlcf8Tyr4cqMNYyqYrF6A/lreqKtmnyme4HoohAV6SST
-sol4Zvf7EQOU0qU55wdext0ETit18f4R0dUIb0Gkzg==
+AcLBXAQAAQoABgUCZQCodgAKCRDgT5vottzAEujqEACcHNCxFiARmLd3yquIsRXQ40LWY5VOoPqT
+oLK5po2/BtewQXBMQJST1KHwzpmxFWabbD5mNEe6w/+oP2p/OjtHKrpwDD9SSSYgYlUn4G5ub/Zi
+ufMuf9Hqqqyr2Zy2+RaCLt+Vf0YdfSxStPvmPAWtLFSb73seMWQ0lcfLYgHKgu6cSzW7JfBrGvdl
+ZDEyFg4fhfsylrjkQdgMofR4XJSUoj5HElgsIiHVJnF3mlrzDb/N93v9S8Wd028h4iW+lu1UVuB7
+ui4IDAStS9qOireZlqtxreVTdqIQoLL0xc13P5MTYj3mfQYQnhq+I3iKejbQ3xeu9Ka2x5LG8pZ9
+C9DrSJ2KjrFFfNIatxAQxoaHwBp9DRsP9wuHw+K7nFwxyKGUkjVM79Bu0pCc4pKWqPSywti7XETV
+reLMBSEze7W4S/zmYjBsnaEgn97ZypIGXkEeUs2RNwq0wY9ZhSCEl80Jot+Y2xzuZxX2PdLIQWFB
+dykU9HvuMB74/Jo6gQKGmmlEJ1Yosev8VL6aUsykJR0HR0Diyh9U5mGxgC3c/v24cyNnjlALXytg
+xzeJ7aDyB3cRYsiRAX/xHIy5V8IegcscSuxTN1p1yhYloy8Nqfy3P8wS8w+P88EmA+OiVEFQXJXo
+QtE/gNFnHRge1nnqLl7BQmomH5L8fXR4LZTPXBUcAg==


### PR DESCRIPTION
This adds a pc-dangerous.img target to ease building unsigned images as well as updating the models to use stable channels wherever possible and includes gnome-system-monitor.