### PR TITLE
Add ubuntu-core-desktop-init snap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 EXTRA_SNAPS =
-ALL_SNAPS = $(EXTRA_SNAPS) eog evince firefox gnome-calculator gnome-characters gnome-clocks gnome-font-viewer gnome-logs gnome-text-editor gnome-weather
+ALL_SNAPS = $(EXTRA_SNAPS) eog evince firefox gnome-calculator gnome-characters gnome-clocks gnome-font-viewer gnome-logs gnome-text-editor gnome-weather ubuntu-core-desktop-init
 
 all: pc.tar.gz
 


### PR DESCRIPTION
This snap is required for the new setup system based on the ubuntu-core-desktop-init flutter code.