### PR TITLE
eog -> loupe, make workshops optional and don't allow removal for the oobe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 
 EXTRA_SNAPS =
-ALL_SNAPS = $(EXTRA_SNAPS) eog evince firefox gnome-calculator gnome-characters gnome-clocks gnome-font-viewer gnome-logs gnome-text-editor gnome-weather ubuntu-core-desktop-init
-
+ALL_SNAPS = $(EXTRA_SNAPS) evince firefox gnome-calculator gnome-characters gnome-clocks gnome-font-viewer gnome-logs gnome-system-monitor gnome-text-editor gnome-weather loupe snapd-desktop-integration snap-store ubuntu-core-desktop-init workshops
 all: pc.tar.gz
 
 pc.img: ubuntu-core-desktop-22-amd64.model $(EXTRA_SNAPS)

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -6,7 +6,7 @@
     "model": "ubuntu-core-desktop-22-amd64-dangerous",
     "display-name":"Ubuntu Core Desktop 22 (amd64) (dangerous)",
     "architecture": "amd64",
-    "revision": "4",
+    "revision": "5",
     "timestamp": "2023-10-02T19:10:01+00:00",
     "grade": "dangerous",
     "storage-safety": "prefer-encrypted",

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -20,7 +20,7 @@
         },
         {
             "name": "pc-kernel",
-            "default-channel": "22/stable",
+            "default-channel": "23.10/stable",
             "type": "kernel",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -7,7 +7,7 @@
     "display-name":"Ubuntu Core Desktop 22 (amd64) (dangerous)",
     "architecture": "amd64",
     "revision": "5",
-    "timestamp": "2023-10-02T19:10:01+00:00",
+    "timestamp": "2023-10-21T10:19:41+00:00",
     "grade": "dangerous",
     "storage-safety": "prefer-encrypted",
     "base": "core22-desktop",

--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -97,10 +97,10 @@
             "id": "JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS"
         },
         {
-            "name": "eog",
+            "name": "loupe",
             "default-channel": "latest/stable",
             "type": "app",
-            "id": "wWtGKn0vLvagfg975tebXfBARLUvU3G7",
+            "id": "Si21Q1kjaZpyJ8TfGbAnxJ4y6KMv7FuW",
             "presence": "optional"
         },
         {
@@ -188,7 +188,8 @@
             "name": "workshops",
             "default-channel": "latest/stable",
             "type": "app",
-            "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8"
+            "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8",
+            "presence": "optional"
         },
         {
             "name": "gnome-system-monitor",
@@ -201,8 +202,7 @@
             "name": "ubuntu-core-desktop-init",
             "default-channel": "latest/stable",
             "type": "app",
-            "id": "xODwiAdjx9KGChvI1z9Xx2JWJE7oLFF6",
-            "presence": "optional"
+            "id": "xODwiAdjx9KGChvI1z9Xx2JWJE7oLFF6"
         }
     ]
 }

--- a/ubuntu-core-desktop-22-amd64-dangerous.model
+++ b/ubuntu-core-desktop-22-amd64-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 4
+revision: 5
 series: 16
 brand-id: canonical
 model: ubuntu-core-desktop-22-amd64-dangerous
@@ -15,7 +15,7 @@ snaps:
     name: pc-desktop
     type: gadget
   -
-    default-channel: 22/stable
+    default-channel: 23.10/stable
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
@@ -81,8 +81,8 @@ snaps:
     type: app
   -
     default-channel: latest/stable
-    id: wWtGKn0vLvagfg975tebXfBARLUvU3G7
-    name: eog
+    id: Si21Q1kjaZpyJ8TfGbAnxJ4y6KMv7FuW
+    name: loupe
     presence: optional
     type: app
   -
@@ -158,6 +158,7 @@ snaps:
     default-channel: latest/stable
     id: JMjaFobGn56fh1HepiaGuCxQgbWYnHc8
     name: workshops
+    presence: optional
     type: app
   -
     default-channel: latest/stable
@@ -169,19 +170,18 @@ snaps:
     default-channel: latest/stable
     id: xODwiAdjx9KGChvI1z9Xx2JWJE7oLFF6
     name: ubuntu-core-desktop-init
-    presence: optional
     type: app
 storage-safety: prefer-encrypted
-timestamp: 2023-10-02T19:10:01+00:00
+timestamp: 2023-10-21T10:19:41+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZRsY3QAKCRDgT5vottzAEtaWEAC4qc9L0EAa6xW1z0L4Bd6o/0OMjrfSlLuL
-3RQE5itgee/NMJY5Uv8qsazixK8DlKPrIHOnqfqwncWeQRtnYX+HcKKqA+OJzNMjLsWhgy2CnSsu
-qXXB9Bil6/Tu/+WXnPJiAhJDR9a+S2E58/+F5rSm/8jHCZJKGE+Aysj8v2eLBgQaMtuju/Q+/dWF
-jrvCd0SowZh+z2I5WM/YL5MFfKjl+wxu6+6jjF7pWC45/zrudq79QUGeAq3VAx0dDGQ3OPGaYtFq
-5hTZrJwnFuXakELyKYx/UgPg2by8dtaJUEqm5eD4wjgNFrAJvP4fXMVhKXzmbzgSOE8bEgowEa53
-02Dss3u1+NIDvFYQrAe2FVwwshLUt3H/4ne8JOAr6hx6y/ZlPRUt0VJSvXhYesRPy08V4ytpCORp
-+5jsAoz7Gzjtdc8bBWWB4GzkZ1z7AxKoZUUn6jfvlBQtQBISiK1iasprN0CqP7ApYfx6bMmv7JWr
-1FLDZFgfmZ/RXHlqazNAyrRP+tJfa6ZlVSc43uq+DUtCFDYDad7hsoHAK21yg7qG/XuA40XHS/Hw
-zmadpW5V0/XSsAZEVdAoflGw+45+Ym9X4jlWGMbMewRhUzPlQkvdD2teAlGbOBmFHptuLaWLlTBV
-Qi5PcoeMA4bwUfJzvVdvcULgmST7mMZvtaY0DDVtFQ==
+AcLBXAQAAQoABgUCZTP+wgAKCRDgT5vottzAEjbeD/9JYnSaSKUUMFhcLTQgQso1GiJkcjVPHcFr
+1ENiu8AKoGrjEeqAu3KO4n0M3rAZkgwJEz7B83AsFZELYuligJ9riJDMMw6UzTQNZQ1e1wnNbHdk
+MXhLY2U2mwq2yZHm8fnZ+QEM9IhyDwj+KeuUgFnVsQGAhtulHlgIhf8e6mY8AOK+wWp+pK9i2+g7
+Kx8tFvvzGzdtJgC8IoLV7LliOI0y88yug4QV3vIkRSi4gWqbI+hMQSjlD04wHXgzxJ4Brz7kQwY7
+fsu03cQp+8WImWvXU+MJSCrpmajphgmD/po/LjbIHtoaiL5iu+W4EjDRQSmY1i4mFE8bfrHpHFD8
+rAE/hn4jnj6isrUWuqEIjDGA0Uu7K5wIYxOa/hQJqIFq9leplYRf6U3sruCLIk90JAEtFKnu/RsP
+gfuDYqmPzRf1NiTtIB25Tpt37cNX/I4vkSZoJSRYZ5DtA11ydv3djNKU+6NGOggnp7+9fgfT8jy0
+QbN9zGvXvXN1dQ8KoFwMyj8NwLZ6yoB6MrxbxztII22JeZjz9Bikvt+Mf6bjkN7Kgy1aqbdEHTVp
+1k7mpgRS8Eqx2KO4WId8zDlCU9+AyAhRgDorlr2SjURR8hrzvbaVVm+FDesvoj9o3axVvyXdRuad
+LHyZ0L837/PLrLhFDvayB1ik4U5U67m3Re49zlUXjQ==

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -6,7 +6,7 @@
     "model": "ubuntu-core-desktop-22-amd64",
     "display-name":"Ubuntu Core Desktop 22 (amd64)",
     "architecture": "amd64",
-    "revision": "4",
+    "revision": "5",
     "timestamp": "2023-10-02T19:10:01+00:00",
     "grade": "signed",
     "storage-safety": "prefer-encrypted",

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -97,10 +97,10 @@
             "id": "JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS"
         },
         {
-            "name": "eog",
+            "name": "loupe",
             "default-channel": "latest/stable",
             "type": "app",
-            "id": "wWtGKn0vLvagfg975tebXfBARLUvU3G7",
+            "id": "Si21Q1kjaZpyJ8TfGbAnxJ4y6KMv7FuW",
             "presence": "optional"
         },
         {
@@ -189,6 +189,7 @@
             "default-channel": "latest/stable",
             "type": "app",
             "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8"
+            "presence": "optional"
         },
         {
             "name": "gnome-system-monitor",
@@ -201,8 +202,7 @@
             "name": "ubuntu-core-desktop-init",
             "default-channel": "latest/stable",
             "type": "app",
-            "id": "xODwiAdjx9KGChvI1z9Xx2JWJE7oLFF6",
-            "presence": "optional"
+            "id": "xODwiAdjx9KGChvI1z9Xx2JWJE7oLFF6"
         }
     ]
 }

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -20,7 +20,7 @@
         },
         {
             "name": "pc-kernel",
-            "default-channel": "22/stable",
+            "default-channel": "23.10/stable",
             "type": "kernel",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -7,7 +7,7 @@
     "display-name":"Ubuntu Core Desktop 22 (amd64)",
     "architecture": "amd64",
     "revision": "5",
-    "timestamp": "2023-10-02T19:10:01+00:00",
+    "timestamp": "2023-10-21T10:19:41+00:00",
     "grade": "signed",
     "storage-safety": "prefer-encrypted",
     "base": "core22-desktop",
@@ -188,7 +188,7 @@
             "name": "workshops",
             "default-channel": "latest/stable",
             "type": "app",
-            "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8"
+            "id": "JMjaFobGn56fh1HepiaGuCxQgbWYnHc8",
             "presence": "optional"
         },
         {

--- a/ubuntu-core-desktop-22-amd64.model
+++ b/ubuntu-core-desktop-22-amd64.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 4
+revision: 5
 series: 16
 brand-id: canonical
 model: ubuntu-core-desktop-22-amd64
@@ -15,7 +15,7 @@ snaps:
     name: pc-desktop
     type: gadget
   -
-    default-channel: 22/stable
+    default-channel: 23.10/stable
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
@@ -81,8 +81,8 @@ snaps:
     type: app
   -
     default-channel: latest/stable
-    id: wWtGKn0vLvagfg975tebXfBARLUvU3G7
-    name: eog
+    id: Si21Q1kjaZpyJ8TfGbAnxJ4y6KMv7FuW
+    name: loupe
     presence: optional
     type: app
   -
@@ -158,6 +158,7 @@ snaps:
     default-channel: latest/stable
     id: JMjaFobGn56fh1HepiaGuCxQgbWYnHc8
     name: workshops
+    presence: optional
     type: app
   -
     default-channel: latest/stable
@@ -169,19 +170,18 @@ snaps:
     default-channel: latest/stable
     id: xODwiAdjx9KGChvI1z9Xx2JWJE7oLFF6
     name: ubuntu-core-desktop-init
-    presence: optional
     type: app
 storage-safety: prefer-encrypted
-timestamp: 2023-10-02T19:10:01+00:00
+timestamp: 2023-10-21T10:19:41+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZRsY3QAKCRDgT5vottzAEr/8D/48j/60TL+DVy18Yg8YKFMbguc+YUm6upae
-dLT5f9HAkpLtgfjPOO0l8nlxqA8FyntdY6PV7cMn4a8P3Bs1xnb5TrGRwMhdgBpWOMRLE3w83TUV
-2bNy1lhVg/7qwhkyZDXuU5cgWRWzBhkHVtZccjih2V05Q7aknpq/w1JJ8gt5GTPQ9mLc8eGZ365d
-mX8INU5Uyf0Qi/LZK2HiDzwZt0N/MDWaacz1K09lLOx2DosInUtBxgT7JO2+yZVVGrYLLH75pogU
-yp0uv0KlV/yxJMN6Q1xwyfcSxgkWiFdnMRSG+uNpafzNnp2dvSnpAMOonjtTVFHiLg6QwPty/zJp
-8chu94AKXhvH0P+3Y+/byT+y2EkDqnj2LGrd2cHedYqZx1FBHPYk7sKnYR8STC20HXHkV2GzaZ6P
-EtRdnII9u0TJiahwSg5UTG9syNijoas2J3ez5nShsAMQ4mzSou0Nhj0RJgg95osjXBAIMosVz1QA
-PBHTXno4LxBHlVp0KkDeDPv8f+SMtkOLplpCnDKkKMQZEbljKUqJgd3XLXdhyAX5Ghu+w1wY1Fjy
-rsuCmzYFa8rLC9kts3UmZbgBvJvIESkO8DxrPfjpvRZiy6F/RD0bpNr9sXpC8Lk12GI17u7gj+35
-HwlSdeuin9SBQ6cPXKA0MpwdIltZUqOyvxe+bMXFTQ==
+AcLBXAQAAQoABgUCZTP+wgAKCRDgT5vottzAEia0D/9FyEOb4Qai+sJQ/ilVqZ1L0FicTIwa9/Ae
+khv5xXYGmukSzkIUGNYjvcCJByxgMiDsFOIIzrOYlJPmRFtdFOwm3KGS2JGthIUbQfElVbyPswZh
+cgqYVuGMiRw8udlZHOmy2rWIKxo/uLMEsZzZuk83nC+ZzAoQoHOmcELuRtIc1qz9XAf6n7pd79S2
+10cxG7vuaA1iVbqqtbSlQCAdKTdOCxw2/NHTZ8mIRtAQZGA1LP8IMEyv2Fi3FVpmN2derV78sO3f
+kCf/KdYeD6d1a03WchIDsuPlvTpTOU3TSX07QWj+WrZHMDh9gpQHDdSIWswBCPIHa10R6aDRRUUK
+/5dJDq77/CyY/Q/ivcAuFiTceghKVcx3Zci+VX2WgvLK9qYHYHSilb70nTvsDFUA/bKep57/xqeG
+j03cvUaqHb6li2T2SmyzaQOGV5MF6XxlhcLWY19PHc2/ocLpukL4vxkl18Ur3FoYAOLODwrlxueS
+FDu7u+qf+Ki2+f0ZtN70EPcFAQAJ4C0N6f9j9Z+9BQptTlVwrIzIUxIwxtkp27YvERno6bZPBRYs
+T4YdzVSdPKXsItT/GUiqYwdgPTi61FZXTN/47yIaHZLUwMT9gg/9XgNqIHKIdFHxm6GWVxL0AqOp
+JPIfqrsmVbewevzwV1Rgo1LbPKVVrjqPtW0QQlkS8w==


### PR DESCRIPTION
* switch from eog to loupe
* make workshops optional
* don't allow removal of ubuntu-core-desktop-init as it's expected to be there for the oobe
* update kernel to 23.10/stable