### PR TITLE
bump the image size 20 GB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ all: pc.tar.gz
 
 pc.img: ubuntu-core-desktop-22-amd64.model $(EXTRA_SNAPS)
 	rm -rf img/
-	ubuntu-image snap --output-dir img --image-size 12G \
+	ubuntu-image snap --output-dir img --image-size 20G \
 	  $(foreach snap,$(ALL_SNAPS),--snap $(snap)) $<
 	mv img/pc.img .
 
 pc-dangerous.img: ubuntu-core-desktop-22-amd64-dangerous.model $(EXTRA_SNAPS)
 	rm -rf dangerous/
-	ubuntu-image snap --output-dir dangerous --image-size 12G \
+	ubuntu-image snap --output-dir dangerous --image-size 20G \
 	  $(foreach snap,$(ALL_SNAPS),--snap $(snap)) $<
 	mv dangerous/pc.img pc-dangerous.img
 


### PR DESCRIPTION
bump the image size to 20 GB so VM users have enough disk space to create an LXD container if they like.