### PR TITLE
Missing lshw

### DIFF
--- a/image/core-desktop.yaml
+++ b/image/core-desktop.yaml
@@ -38,6 +38,7 @@ customization:
     - name: squashfs-tools
     - name: snapd
     - name: cloud-init
+    - name: lshw
   extra-snaps:
     - name: ubuntu-core-desktop-installer
     - name: core22


### PR DESCRIPTION
The package lshw is missing, and it's required. Without it, the installation fails.