### PR TITLE
Fix corners

### DIFF
--- a/image/core-desktop.yaml
+++ b/image/core-desktop.yaml
@@ -39,6 +39,8 @@ customization:
     - name: snapd
     - name: cloud-init
     - name: lshw
+    - name: yaru-theme-gtk
+    - name: gsettings-desktop-schemas
   extra-snaps:
     - name: ubuntu-core-desktop-installer
     - name: core22
@@ -48,6 +50,8 @@ customization:
       - path: /cdrom/casper
         permissions: 0755
       - path: /etc/systemd/system/snap.ubuntu-core-desktop-installer.miriway.service.d
+        permissions: 0755
+      - path: /etc/gtk-3.0
         permissions: 0755
     copy-file:
       - source: 99-custom-networking.cfg
@@ -66,6 +70,8 @@ customization:
         destination: /sbin/casper-enable
       - source: override.conf
         destination: /etc/systemd/system/snap.ubuntu-core-desktop-installer.miriway.service.d/override.conf
+      - source: gtk-3.0-settings.ini
+        destination: /etc/gtk-3.0/settings.ini
     execute:
       - path: /usr/bin/systemd-machine-id-setup
       - path: /sbin/casper-enable

--- a/image/gtk-3.0-settings.ini
+++ b/image/gtk-3.0-settings.ini
@@ -1,0 +1,5 @@
+[Settings]
+gtk-theme-name = Yaru
+gtk-icon-theme-name = Yaru
+gtk-sound-theme-name = Yaru
+gtk-icon-sizes = panel-menu-bar=24,24


### PR DESCRIPTION
This patch adds the Gtk themes and the gsettings schemas to the installer, which fixes the window corners.

Still to do is the default color.