### PR TITLE
Add ubuntu-desktop-session snap to the list

### DIFF
--- a/ubuntu-core-desktop-22-amd64-dangerous.json
+++ b/ubuntu-core-desktop-22-amd64-dangerous.json
@@ -203,6 +203,12 @@
             "default-channel": "latest/stable",
             "type": "app",
             "id": "xODwiAdjx9KGChvI1z9Xx2JWJE7oLFF6"
+        },
+        {
+            "name": "ubuntu-desktop-init",
+            "default-channel": "latest/candidate",
+            "type": "app",
+            "id": "tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5"
         }
     ]
 }

--- a/ubuntu-core-desktop-22-amd64.json
+++ b/ubuntu-core-desktop-22-amd64.json
@@ -203,6 +203,12 @@
             "default-channel": "latest/stable",
             "type": "app",
             "id": "xODwiAdjx9KGChvI1z9Xx2JWJE7oLFF6"
+        },
+        {
+            "name": "ubuntu-desktop-init",
+            "default-channel": "latest/candidate",
+            "type": "app",
+            "id": "tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5"
         }
     ]
 }


### PR DESCRIPTION
It is required to be able to automagically install it for future versions.