### PR TITLE
model: add an Ubuntu Core Desktop 24 model

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install build dependencies
@@ -23,9 +23,10 @@ jobs:
         run: |
           make
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: image
           path: |
             README.md
             *.tar.gz
+          compression-level: 0 # content is already compressed

--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -9,3 +9,5 @@ jobs:
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v1
+        with:
+          accept-existing-contributors: true

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 
 EXTRA_SNAPS =
-ALL_SNAPS = $(EXTRA_SNAPS) evince firefox gnome-calculator gnome-characters gnome-clocks gnome-font-viewer gnome-logs gnome-system-monitor gnome-text-editor gnome-weather loupe snapd-desktop-integration snap-store ubuntu-core-desktop-init workshops
+ALL_SNAPS = $(EXTRA_SNAPS) firefox
 all: pc.tar.gz
 
-pc.img: ubuntu-core-desktop-22-amd64.model $(EXTRA_SNAPS)
+pc.img: ubuntu-core-desktop-24-amd64.model $(EXTRA_SNAPS)
 	rm -rf img/
 	ubuntu-image snap --output-dir img --image-size 20G \
 	  $(foreach snap,$(ALL_SNAPS),--snap $(snap)) $<
 	mv img/pc.img .
 
-pc-dangerous.img: ubuntu-core-desktop-22-amd64-dangerous.model $(EXTRA_SNAPS)
+pc-dangerous.img: ubuntu-core-desktop-24-amd64-dangerous.model $(EXTRA_SNAPS)
 	rm -rf dangerous/
 	ubuntu-image snap --output-dir dangerous --image-size 20G \
 	  $(foreach snap,$(ALL_SNAPS),--snap $(snap)) $<

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ in a Qemu virtual machine by following these instructions:
     # Delete VM if already registered
     virsh --connect qemu:///session undefine --nvram core-desktop
     virt-install --connect qemu:///session --name core-desktop \
-      --memory 2048 --vcpus 2 --boot uefi --os-variant ubuntu22.04 \
+      --memory 2048 --vcpus 2 --boot uefi --os-variant ubuntu24.04 \
       --video virtio,accel3d=no --graphics spice \
       --import --disk path=$(pwd)/pc.img,format=raw
     ```
@@ -50,11 +50,23 @@ repositories. Namely:
 
 | Snap | Repo | Recipe | Notes |
 | ---- | ---- | ------ | ----- |
-| `core22-desktop` | [core-base-desktop](https://github.com/canonical/core-base-desktop) | [via launchpad](https://launchpad.net/~ubuntu-desktop/+snap/core22-desktop) | base snap, forked from `core22` to integrate GDM graphical login |
-| `pc-desktop` | [pc-amd64-gadget-desktop](https://github.com/canonical/pc-amd64-gadget-desktop) | [via launchpad](https://launchpad.net/~ubuntu-desktop/pc-gadget-desktop/+snap/pc-amd64-gadget-desktop-core22) | gadget snap, forked from `pc`, using `core22-desktop` as a base |
+| `core24-desktop` | [core-base-desktop:24](https://github.com/canonical/core-base-desktop/tree/24) | [via launchpad](https://launchpad.net/~desktop-snappers/ubuntu-core-desktop/+snap/core24-desktop) | base snap, forked from `core24` to integrate GDM graphical login |
+| `pc-desktop` | [pc-amd64-gadget-desktop:24](https://github.com/canonical/pc-amd64-gadget-desktop/tree/24) | [via launchpad](https://launchpad.net/~ubuntu-desktop/pc-gadget-desktop/+snap/pc-amd64-gadget-desktop-core24) | gadget snap, forked from `pc`, using `core24-desktop` as a base |
+| `ubuntu-desktop-session` | [ubuntu-desktop-session-snap:24](https://github.com/canonical/ubuntu-desktop-session-snap/tree/24) | [via launchpad](https://launchpad.net/~ubuntu-desktop/+snap/ubuntu-desktop-session-snap-core24) | provides the confined desktop session |
+| `snapd` | [ubuntu-core-desktop-snapd:master](https://github.com/canonical/ubuntu-core-desktop-snapd) | [via launchpad](https://launchpad.net/~snappy-dev/+snap/ubuntu-core-desktop-snapd) | a branch of snapd with additional changes not yet merged to mainline |
+
+<details>
+<summary>Core 22 Repositories</summary>
+
+| Snap | Repo | Recipe | Notes |
+| ---- | ---- | ------ | ----- |
+| `core22-desktop` | [core-base-desktop:22](https://github.com/canonical/core-base-desktop/tree/22) | [via launchpad](https://launchpad.net/~ubuntu-desktop/+snap/core22-desktop) | base snap, forked from `core22` to integrate GDM graphical login |
+| `pc-desktop` | [pc-amd64-gadget-desktop:22](https://github.com/canonical/pc-amd64-gadget-desktop/tree/22) | [via launchpad](https://launchpad.net/~ubuntu-desktop/pc-gadget-desktop/+snap/pc-amd64-gadget-desktop-core22) | gadget snap, forked from `pc`, using `core22-desktop` as a base |
 | `pi-desktop` | [pi-desktop](https://github.com/canonical/pi-desktop) | [via launchpad](https://launchpad.net/~desktop-snappers/+snap/pi-desktop) | Pi gadget snap, forked from `pi`, using `core22-desktop` as a base |
-| `ubuntu-desktop-session` | [ubuntu-desktop-session-snap](https://github.com/canonical/ubuntu-desktop-session-snap) | [via launchpad](https://launchpad.net/~ubuntu-desktop/+snap/ubuntu-desktop-session-snap-core22) | provides the confined desktop session |
+| `ubuntu-desktop-session` | [ubuntu-desktop-session-snap:22](https://github.com/canonical/ubuntu-desktop-session-snap/tree/22) | [via launchpad](https://launchpad.net/~ubuntu-desktop/+snap/ubuntu-desktop-session-snap-core22) | provides the confined desktop session |
 | `snapd` | [ubuntu-core-desktop-snapd](https://github.com/canonical/ubuntu-core-desktop-snapd) | [via ~snappy-dev](https://launchpad.net/~snappy-dev/+snap/ubuntu-core-desktop-snapd) | a branch of snapd with additional changes not yet merged to mainline |
+
+</details>
 
 In addition, the base snap uses packages from the [desktop-snappers
 core-desktop

--- a/ubuntu-core-desktop-24-amd64-dangerous.json
+++ b/ubuntu-core-desktop-24-amd64-dangerous.json
@@ -1,0 +1,131 @@
+{
+    "type": "model",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "series": "16",
+    "model": "ubuntu-core-desktop-24-amd64-dangerous",
+    "display-name":"Ubuntu Core Desktop 24 (amd64) (dangerous)",
+    "architecture": "amd64",
+    "revision": "0",
+    "timestamp": "2024-07-04T10:33:44+08:00",
+    "grade": "dangerous",
+    "storage-safety": "prefer-encrypted",
+    "base": "core24-desktop",
+    "snaps": [
+        {
+            "name": "pc-desktop",
+            "default-channel": "24/stable",
+            "type": "gadget",
+            "id": "mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy"
+        },
+        {
+            "name": "pc-kernel",
+            "default-channel": "24-hwe/stable",
+            "type": "kernel",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "snapd",
+            "default-channel": "latest/edge/ubuntu-core-desktop",
+            "type": "snapd",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "core24-desktop",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "GY5GohJ4F1ZsWpkosG0joeZyDfHzTZrD"
+        },
+        {
+            "name": "ubuntu-desktop-session",
+            "default-channel": "24/stable",
+            "type": "app",
+            "id": "LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN"
+        },
+        {
+            "name": "core22",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+        },
+        {
+            "name": "core24",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "network-manager",
+            "default-channel": "24/stable",
+            "type": "app",
+            "id": "RmBXKl6HO6YOC2DE4G2q1JzWImC04EUy"
+        },
+        {
+            "name": "bare",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "EISPgh06mRh1vordZY9OZ34QHdd7OrdR"
+        },
+        {
+            "name": "gtk-common-themes",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "jZLfBRzf1cYlYysIjD2bwSzNtngY0qit"
+        },
+        {
+            "name": "gnome-42-2204",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3"
+        },
+        {
+            "name": "cups",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "m1eQacDdXCthEwWQrESei3Zao3d5gfJF"
+        },
+        {
+            "name": "ipp-usb",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "WJKWBUuCDufOFw2p24tvkbbw02plGkbd"
+        },
+        {
+            "name": "avahi",
+            "default-channel": "24/stable",
+            "type": "app",
+            "id": "dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll"
+        },
+        {
+            "name": "bluez",
+            "default-channel": "24/stable",
+            "type": "app",
+            "id": "JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS"
+        },
+        {
+            "name": "firefox",
+            "default-channel": "latest/stable/ubuntu-24.04",
+            "type": "app",
+            "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk",
+            "presence": "optional"
+        },
+        {
+            "name": "snapd-desktop-integration",
+            "default-channel": "latest/edge/ubuntu-core-desktop",
+            "type": "app",
+            "id": "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
+        },
+        {
+            "name": "snap-store",
+            "default-channel": "latest/stable/ubuntu-24.04",
+            "type": "app",
+            "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
+        },
+        {
+            "name": "ubuntu-desktop-init",
+            "default-channel": "latest/candidate",
+            "type": "app",
+            "id": "tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5"
+        }
+    ]
+}

--- a/ubuntu-core-desktop-24-amd64-dangerous.model
+++ b/ubuntu-core-desktop-24-amd64-dangerous.model
@@ -1,0 +1,120 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-desktop-24-amd64-dangerous
+architecture: amd64
+base: core24-desktop
+display-name: Ubuntu Core Desktop 24 (amd64) (dangerous)
+grade: dangerous
+snaps:
+  -
+    default-channel: 24/stable
+    id: mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy
+    name: pc-desktop
+    type: gadget
+  -
+    default-channel: 24-hwe/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge/ubuntu-core-desktop
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: latest/stable
+    id: GY5GohJ4F1ZsWpkosG0joeZyDfHzTZrD
+    name: core24-desktop
+    type: base
+  -
+    default-channel: 24/stable
+    id: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN
+    name: ubuntu-desktop-session
+    type: app
+  -
+    default-channel: latest/stable
+    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    name: core22
+    type: base
+  -
+    default-channel: latest/stable
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: 24/stable
+    id: RmBXKl6HO6YOC2DE4G2q1JzWImC04EUy
+    name: network-manager
+    type: app
+  -
+    default-channel: latest/stable
+    id: EISPgh06mRh1vordZY9OZ34QHdd7OrdR
+    name: bare
+    type: base
+  -
+    default-channel: latest/stable
+    id: jZLfBRzf1cYlYysIjD2bwSzNtngY0qit
+    name: gtk-common-themes
+    type: app
+  -
+    default-channel: latest/stable
+    id: lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3
+    name: gnome-42-2204
+    type: app
+  -
+    default-channel: latest/stable
+    id: m1eQacDdXCthEwWQrESei3Zao3d5gfJF
+    name: cups
+    type: app
+  -
+    default-channel: latest/stable
+    id: WJKWBUuCDufOFw2p24tvkbbw02plGkbd
+    name: ipp-usb
+    type: app
+  -
+    default-channel: 24/stable
+    id: dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll
+    name: avahi
+    type: app
+  -
+    default-channel: 24/stable
+    id: JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS
+    name: bluez
+    type: app
+  -
+    default-channel: latest/stable/ubuntu-24.04
+    id: 3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk
+    name: firefox
+    presence: optional
+    type: app
+  -
+    default-channel: latest/edge/ubuntu-core-desktop
+    id: IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu
+    name: snapd-desktop-integration
+    type: app
+  -
+    default-channel: latest/stable/ubuntu-24.04
+    id: gjf3IPXoRiipCu9K0kVu52f0H56fIksg
+    name: snap-store
+    type: app
+  -
+    default-channel: latest/candidate
+    id: tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5
+    name: ubuntu-desktop-init
+    type: app
+storage-safety: prefer-encrypted
+timestamp: 2024-07-04T10:33:44+08:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCZoYTygAKCRDgT5vottzAEp5GEACX59hc/FHiFzBvTaXzdkH4Dsuqd40jiL/J
+/wFmVcLH4SV8NVcFAVUkKY0rLviLA+ai/W/rOlsq5pbMHcaXiukRSjormeXlH84t7xRy9WTNXYx2
+R6HNJ7LY+twFqCXSxOtGKENXdWwtw5YifCtRSm4l7MKiDb9IbysuDupjZL2l/DqjN0kF3yaVUgVN
+WneI6j94rFlUCzv7L7j3TB4Dh7WeyqlnpDGy5deztl+4wwAWuDDTTHuo8dx4sIYD+L53sAk6MiSI
+BbjFk6QnbQvCodJwawZHjChZU2m/R3Xv8jjVww/1f2zzonx2myoQJCRrnUAUQ4xE28ViqeUJZkl/
+YeJKHa4DxMEQhwG02y4Y7pjVO+UErCruA6xP+g6TuQYC7sHqN5SLnPICPhHdVKyE3ukowwbe9SOm
+Z6gK+vt8QKfnMXoFofmbmaRZz+kp8rYAOYbOH4JjAzFUl4Cd+AnXeP5tt0g0q2Cv8ucJCaNLXg3v
+yhRPHIoiWx/Udl+fHdNPM4Cfdy651IJy6Wxpfv8PQJpmuaUzL23UxY111nmZF1kIgedcSbf+Bsmp
+e0qhWDKftF8nWmXS0RklgmdBskztVCSTflCXn2yo8w2/UAO/1cDUzEaTtjCTVMjcHbMqIDBw0nuf
+dq6yqlLbwLEZWSJTJOBuIpnVcWq+7YFg0RtDyZK2/g==

--- a/ubuntu-core-desktop-24-amd64.json
+++ b/ubuntu-core-desktop-24-amd64.json
@@ -1,0 +1,131 @@
+{
+    "type": "model",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "series": "16",
+    "model": "ubuntu-core-desktop-24-amd64",
+    "display-name":"Ubuntu Core Desktop 24 (amd64)",
+    "architecture": "amd64",
+    "revision": "0",
+    "timestamp": "2024-07-04T10:33:44+08:00",
+    "grade": "signed",
+    "storage-safety": "prefer-encrypted",
+    "base": "core24-desktop",
+    "snaps": [
+        {
+            "name": "pc-desktop",
+            "default-channel": "24/stable",
+            "type": "gadget",
+            "id": "mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy"
+        },
+        {
+            "name": "pc-kernel",
+            "default-channel": "24-hwe/stable",
+            "type": "kernel",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "snapd",
+            "default-channel": "latest/edge/ubuntu-core-desktop",
+            "type": "snapd",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "core24-desktop",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "GY5GohJ4F1ZsWpkosG0joeZyDfHzTZrD"
+        },
+        {
+            "name": "ubuntu-desktop-session",
+            "default-channel": "24/stable",
+            "type": "app",
+            "id": "LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN"
+        },
+        {
+            "name": "core22",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+        },
+        {
+            "name": "core24",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "network-manager",
+            "default-channel": "24/stable",
+            "type": "app",
+            "id": "RmBXKl6HO6YOC2DE4G2q1JzWImC04EUy"
+        },
+        {
+            "name": "bare",
+            "default-channel": "latest/stable",
+            "type": "base",
+            "id": "EISPgh06mRh1vordZY9OZ34QHdd7OrdR"
+        },
+        {
+            "name": "gtk-common-themes",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "jZLfBRzf1cYlYysIjD2bwSzNtngY0qit"
+        },
+        {
+            "name": "gnome-42-2204",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3"
+        },
+        {
+            "name": "cups",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "m1eQacDdXCthEwWQrESei3Zao3d5gfJF"
+        },
+        {
+            "name": "ipp-usb",
+            "default-channel": "latest/stable",
+            "type": "app",
+            "id": "WJKWBUuCDufOFw2p24tvkbbw02plGkbd"
+        },
+        {
+            "name": "avahi",
+            "default-channel": "24/stable",
+            "type": "app",
+            "id": "dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll"
+        },
+        {
+            "name": "bluez",
+            "default-channel": "24/stable",
+            "type": "app",
+            "id": "JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS"
+        },
+        {
+            "name": "firefox",
+            "default-channel": "latest/stable/ubuntu-24.04",
+            "type": "app",
+            "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk",
+            "presence": "optional"
+        },
+        {
+            "name": "snapd-desktop-integration",
+            "default-channel": "latest/edge/ubuntu-core-desktop",
+            "type": "app",
+            "id": "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
+        },
+        {
+            "name": "snap-store",
+            "default-channel": "latest/stable/ubuntu-24.04",
+            "type": "app",
+            "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
+        },
+        {
+            "name": "ubuntu-desktop-init",
+            "default-channel": "latest/candidate",
+            "type": "app",
+            "id": "tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5"
+        }
+    ]
+}

--- a/ubuntu-core-desktop-24-amd64.model
+++ b/ubuntu-core-desktop-24-amd64.model
@@ -1,0 +1,120 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-desktop-24-amd64
+architecture: amd64
+base: core24-desktop
+display-name: Ubuntu Core Desktop 24 (amd64)
+grade: signed
+snaps:
+  -
+    default-channel: 24/stable
+    id: mZqHskGgGDECRCKP7h7ef3Rl2wTwyNfy
+    name: pc-desktop
+    type: gadget
+  -
+    default-channel: 24-hwe/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge/ubuntu-core-desktop
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: latest/stable
+    id: GY5GohJ4F1ZsWpkosG0joeZyDfHzTZrD
+    name: core24-desktop
+    type: base
+  -
+    default-channel: 24/stable
+    id: LVkazk0JLrL0ivuHRlv3wp3bK1nAgwtN
+    name: ubuntu-desktop-session
+    type: app
+  -
+    default-channel: latest/stable
+    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    name: core22
+    type: base
+  -
+    default-channel: latest/stable
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: 24/stable
+    id: RmBXKl6HO6YOC2DE4G2q1JzWImC04EUy
+    name: network-manager
+    type: app
+  -
+    default-channel: latest/stable
+    id: EISPgh06mRh1vordZY9OZ34QHdd7OrdR
+    name: bare
+    type: base
+  -
+    default-channel: latest/stable
+    id: jZLfBRzf1cYlYysIjD2bwSzNtngY0qit
+    name: gtk-common-themes
+    type: app
+  -
+    default-channel: latest/stable
+    id: lATO8HzwVvrAPrlZRAWpfyrJKlAJrZS3
+    name: gnome-42-2204
+    type: app
+  -
+    default-channel: latest/stable
+    id: m1eQacDdXCthEwWQrESei3Zao3d5gfJF
+    name: cups
+    type: app
+  -
+    default-channel: latest/stable
+    id: WJKWBUuCDufOFw2p24tvkbbw02plGkbd
+    name: ipp-usb
+    type: app
+  -
+    default-channel: 24/stable
+    id: dVK2PZeOLKA7vf1WPCap9F8luxTk9Oll
+    name: avahi
+    type: app
+  -
+    default-channel: 24/stable
+    id: JmzJi9kQvHUWddZ32PDJpBRXUpGRxvNS
+    name: bluez
+    type: app
+  -
+    default-channel: latest/stable/ubuntu-24.04
+    id: 3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk
+    name: firefox
+    presence: optional
+    type: app
+  -
+    default-channel: latest/edge/ubuntu-core-desktop
+    id: IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu
+    name: snapd-desktop-integration
+    type: app
+  -
+    default-channel: latest/stable/ubuntu-24.04
+    id: gjf3IPXoRiipCu9K0kVu52f0H56fIksg
+    name: snap-store
+    type: app
+  -
+    default-channel: latest/candidate
+    id: tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5
+    name: ubuntu-desktop-init
+    type: app
+storage-safety: prefer-encrypted
+timestamp: 2024-07-04T10:33:44+08:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCZoYTygAKCRDgT5vottzAEnlLD/4toc4w5IiLm/xmBFL8BVwXXVQsvNNtVYaT
+NGSa+q7OJXeVbPQnnRMK4oH31IbGFngK3IHoc04LK76W2GQzAE4SQxTcV9VTlyPrVc6OeCn9rSWj
+zFX/fOVuD5Wd6OOgNitaHqVHh8CDQFcsdOBICImHG6s0Au1mIDVQvV/DxcnnprJ53yXFCeastuX+
+CnZiB6wOv/dzGHnIbhpUtKg5HV5jZoIkmplWAZr1IXd8gAPvltDzpJYwN6GMHK6SLUD1tgviP4ZB
+gw9IT11DCeB9TOEnsAs7y1YApUdkxMSv4B+Jwew/lkjysncULqFCt6fCD3HEw+OdULb/OrFnYcSV
+4NqPBop/9mi+CB5Fs3ubtlKxK9VnSJbLpXsyBeDvljVKp0MvNBpCTJnlGtRvQE/bHLpaAhRRsP0R
+6cUqd1ieRm4wp/1/v+zMjdp6VL7co0/a6jZgtfptCMnCC6Z0KdLWGQjaXDwxNStqMK3h/Au2YWDc
+ZgZ/+wTxMlDyU4i4gg+rByV2yPHfGeVpN7D7nuY8OWXq1ezESY6K5fsOW77/XEjZJOI3BFOJ6Xnl
+2ATKBs6uSmMPQSZo21sk+E0c2gH8qj6L6mUcAz2qvilur9w4uEM3TRfZcAKPN+8lV44eB8/aZpq7
+GfjsXFa+DpXJzWdC91SP4yIeojoj3OAl4gNwt0c85g==


### PR DESCRIPTION
This branch add signed models for Ubuntu Core Desktop 24, and updates the build scripts to use them instead of the older UCD 22 models.

The main changes compared to the UCD 22 model are:

1. Use `core24-desktop` as a base.
2. Use `24/edge` channel for `pc-desktop` and `ubuntu-desktop-session`.
3. Use `24/stable` channel for `pc-kernel` and `network-manager`.
4. Include `core24` snap (used by new `avahi`, `bluez`, and `network-manager`).
5. Drop all the apps except for `snap-store` and `firefox`.
6. Replace `ubuntu-core-desktop-init` with `ubuntu-desktop-init`.