### PR TITLE
Make bootable image with text-mode installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,17 @@ pi-dangerous.img: ubuntu-core-desktop-22-pi-dangerous.model $(EXTRA_SNAPS)
 
 .PHONY: all
 
+ubuntu-core-desktop-22-amd64.img: pc-dangerous.img
+	rm -rf output/
+	cat image/install-sources.yaml.in |sed "s/@FILE@/$</g"|sed "s/@SIZE@/$(shell stat -c%s $<)/g" > image/install-sources.yaml
+	sudo ubuntu-image classic --debug -O output/ image/core-desktop.yaml
+	sudo chown -R $(shell id -u):$(shell id -g) output
+	mv output/ubuntu-core-desktop-22-amd64.img .
+
+
 clean:
 	sudo rm -rf img
 	sudo rm -rf output
-	sudo rm -rf image
+	sudo rm -rf image/isolinux
+	sudo rm -rf dangerous
 	sudo rm -f pc*.img.xz pc*.img pc*.tar.gz ubuntu-core-desktop-*.img ubuntu-core-desktop-*.img.xz ubuntu-core-desktop-*.iso image/install-sources.yaml

--- a/image/autoinstall.yaml
+++ b/image/autoinstall.yaml
@@ -1,0 +1,11 @@
+version: 1
+source:
+  id: ubuntu-core-desktop
+  search_drivers: false
+interactive-sections:
+  - locale
+  - storage
+identity:
+  username: ubuntu
+  password: '$1$zB3Qu2ef$TKLhQpQlKRyCZGUdHFFMH/'
+  hostname: ubuntu

--- a/image/core-desktop.yaml
+++ b/image/core-desktop.yaml
@@ -1,0 +1,71 @@
+name: ubuntu-core-desktop-amd64
+display-name: Ubuntu Core Desktop amd64
+revision: 1
+architecture: amd64
+series: noble
+class: preinstalled
+kernel: linux-image-generic
+gadget:
+  url: "https://git.launchpad.net/~canonical-foundations/snap-pc/+git/github-mirror-amd64"
+  branch: classic
+  type: "git"
+rootfs:
+  components:
+    - main
+    - restricted
+  seed:
+    urls:
+      - "git://git.launchpad.net/~ubuntu-core-dev/ubuntu-seeds/+git/"
+    branch: noble
+    names:
+      - minimal
+customization:
+  cloud-init:
+    user-data: |
+      #cloud-config
+      chpasswd:
+        expire: false
+        users:
+          - name: ubuntu
+            password: ubuntu
+            type: text
+    meta-data: |
+      #cloud-config
+      dsmode: local
+      instance_id: ubuntu-core-desktop
+  extra-packages:
+    - name: squashfs-tools
+    - name: snapd
+    - name: cloud-init
+    - name: lshw
+  extra-snaps:
+    - name: subiquity
+    - name: core22
+    - name: snapd
+  manual:
+    make-dirs:
+      - path: /cdrom/casper
+        permissions: 0755
+    copy-file:
+#      - source: 99-custom-networking.cfg
+#        destination: /etc/cloud/cloud.cfg.d/99-custom-networking.cfg
+      - source: install-sources.yaml
+        destination: /cdrom/casper/install-sources.yaml
+      - source: autoinstall.yaml
+        destination: /autoinstall.yaml
+      - source: ../pc-dangerous.img
+        destination: /cdrom/casper/pc.img
+      - source: subiquity-enable
+        destination: /sbin/subiquity-enable
+      # - source: subiquity-installer.service
+      #   destination: /lib/systemd/system/subiquity-installer.service
+    execute:
+      - path: /usr/bin/systemd-machine-id-setup
+      - path: /sbin/subiquity-enable
+artifacts:
+  img:
+    -
+      name: ubuntu-core-desktop-22-amd64.img
+  manifest:
+    name: ubuntu-core-desktop-pc-amd64.manifest
+

--- a/image/core-desktop.yaml
+++ b/image/core-desktop.yaml
@@ -57,8 +57,10 @@ customization:
         destination: /cdrom/casper/pc.img
       - source: subiquity-enable
         destination: /sbin/subiquity-enable
-      # - source: subiquity-installer.service
-      #   destination: /lib/systemd/system/subiquity-installer.service
+      - source: subiquity-launcher.service
+        destination: /lib/systemd/system/subiquity-launcher.service
+      - source: subiquity-launch
+        destination: /sbin
     execute:
       - path: /usr/bin/systemd-machine-id-setup
       - path: /sbin/subiquity-enable

--- a/image/install-sources.yaml
+++ b/image/install-sources.yaml
@@ -1,0 +1,11 @@
+- default: true
+  description:
+    en: Ubuntu Core Desktop.
+  id: ubuntu-core-desktop
+  locale_support: none
+  name:
+    en: Ubuntu Core Desktop
+  path: pc-dangerous.img
+  type: dd:file
+  size: 21474836480
+  variant: core

--- a/image/install-sources.yaml.in
+++ b/image/install-sources.yaml.in
@@ -1,0 +1,11 @@
+- default: true
+  description:
+    en: Ubuntu Core Desktop.
+  id: ubuntu-core-desktop
+  locale_support: none
+  name:
+    en: Ubuntu Core Desktop
+  path: @FILE@
+  type: dd:file
+  size: @SIZE@
+  variant: core

--- a/image/subiquity-enable
+++ b/image/subiquity-enable
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+/usr/bin/systemctl disable getty@tty1.service
+/usr/bin/systemctl enable snap.subiquity.subiquity-server.service
+/usr/bin/systemctl enable snap.subiquity.subiquity-service.service
+sed -i 's#Type=simple#Type=simple\nRestartSec=3#g' /etc/systemd/system/snap.subiquity.subiquity-service.service

--- a/image/subiquity-enable
+++ b/image/subiquity-enable
@@ -2,5 +2,4 @@
 
 /usr/bin/systemctl disable getty@tty1.service
 /usr/bin/systemctl enable snap.subiquity.subiquity-server.service
-/usr/bin/systemctl enable snap.subiquity.subiquity-service.service
-sed -i 's#Type=simple#Type=simple\nRestartSec=3#g' /etc/systemd/system/snap.subiquity.subiquity-service.service
+/usr/bin/systemctl enable subiquity-launcher.service

--- a/image/subiquity-installer.service
+++ b/image/subiquity-installer.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Launches subiquity
+After=getty@tty1.service
+
+[Service]
+Type=simple
+ExecStart=bin/sh /snap/subiquity/current/usr/bin/subiquity-server
+StandardInput=tty
+StandardOutput=tty
+StandardError=tty
+TTYPath=/dev/tty1

--- a/image/subiquity-installer.service
+++ b/image/subiquity-installer.service
@@ -1,11 +1,8 @@
 [Unit]
 Description=Launches subiquity
 After=getty@tty1.service
+After=snap.subiquity.subiquity-server
 
 [Service]
 Type=simple
 ExecStart=bin/sh /snap/subiquity/current/usr/bin/subiquity-server
-StandardInput=tty
-StandardOutput=tty
-StandardError=tty
-TTYPath=/dev/tty1

--- a/image/subiquity-launch
+++ b/image/subiquity-launch
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+systemctl start snap.subiquity.subiquity-service.service

--- a/image/subiquity-launch
+++ b/image/subiquity-launch
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-systemctl start snap.subiquity.subiquity-service.service
+dmesg -D
+snap run subiquity

--- a/image/subiquity-launcher.service
+++ b/image/subiquity-launcher.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Launches subiquity, both back and front-end
+DefaultDependencies=no
+After=multi-user.target
+After=cloud-final.service
+
+[Service]
+Type=oneshot
+ExecStart=snap run subiquity
+StandardInput=tty
+StandardOutput=tty
+StandardError=tty
+TTYPath=/dev/tty1
+
+[Install]
+WantedBy=multi-user.target

--- a/image/subiquity-launcher.service
+++ b/image/subiquity-launcher.service
@@ -6,7 +6,7 @@ After=cloud-final.service
 
 [Service]
 Type=oneshot
-ExecStart=snap run subiquity
+ExecStart=/sbin/subiquity-launch
 StandardInput=tty
 StandardOutput=tty
 StandardError=tty


### PR DESCRIPTION
This branch allows to create a bootable Core Desktop image using subiquity as a text-mode installer.

Things to do:

 * Put terminal in UTF-8 mode