### PR TITLE
Add pipewire to the models

### DIFF
--- a/ubuntu-core-desktop-24-amd64-dangerous.json
+++ b/ubuntu-core-desktop-24-amd64-dangerous.json
@@ -6,8 +6,8 @@
     "model": "ubuntu-core-desktop-24-amd64-dangerous",
     "display-name":"Ubuntu Core Desktop 24 (amd64) (dangerous)",
     "architecture": "amd64",
-    "revision": "0",
-    "timestamp": "2024-07-04T10:33:44+08:00",
+    "revision": "1",
+    "timestamp": "2025-01-31T10:37:55+01:00",
     "grade": "dangerous",
     "storage-safety": "prefer-encrypted",
     "base": "core24-desktop",
@@ -126,6 +126,12 @@
             "default-channel": "latest/candidate",
             "type": "app",
             "id": "tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5"
+        },
+        {
+            "name": "pipewire",
+            "default-channel": "latest/candidate",
+            "type": "app",
+            "id": "cXXVv4NGwXqlxTVSdrjsuvrPGAHfRSRs"
         }
     ]
 }

--- a/ubuntu-core-desktop-24-amd64-dangerous.model
+++ b/ubuntu-core-desktop-24-amd64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 1
 series: 16
 brand-id: canonical
 model: ubuntu-core-desktop-24-amd64-dangerous
@@ -104,17 +105,22 @@ snaps:
     id: tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5
     name: ubuntu-desktop-init
     type: app
+  -
+    default-channel: latest/candidate
+    id: cXXVv4NGwXqlxTVSdrjsuvrPGAHfRSRs
+    name: pipewire
+    type: app
 storage-safety: prefer-encrypted
-timestamp: 2024-07-04T10:33:44+08:00
+timestamp: 2025-01-31T10:37:55+01:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZoYTygAKCRDgT5vottzAEp5GEACX59hc/FHiFzBvTaXzdkH4Dsuqd40jiL/J
-/wFmVcLH4SV8NVcFAVUkKY0rLviLA+ai/W/rOlsq5pbMHcaXiukRSjormeXlH84t7xRy9WTNXYx2
-R6HNJ7LY+twFqCXSxOtGKENXdWwtw5YifCtRSm4l7MKiDb9IbysuDupjZL2l/DqjN0kF3yaVUgVN
-WneI6j94rFlUCzv7L7j3TB4Dh7WeyqlnpDGy5deztl+4wwAWuDDTTHuo8dx4sIYD+L53sAk6MiSI
-BbjFk6QnbQvCodJwawZHjChZU2m/R3Xv8jjVww/1f2zzonx2myoQJCRrnUAUQ4xE28ViqeUJZkl/
-YeJKHa4DxMEQhwG02y4Y7pjVO+UErCruA6xP+g6TuQYC7sHqN5SLnPICPhHdVKyE3ukowwbe9SOm
-Z6gK+vt8QKfnMXoFofmbmaRZz+kp8rYAOYbOH4JjAzFUl4Cd+AnXeP5tt0g0q2Cv8ucJCaNLXg3v
-yhRPHIoiWx/Udl+fHdNPM4Cfdy651IJy6Wxpfv8PQJpmuaUzL23UxY111nmZF1kIgedcSbf+Bsmp
-e0qhWDKftF8nWmXS0RklgmdBskztVCSTflCXn2yo8w2/UAO/1cDUzEaTtjCTVMjcHbMqIDBw0nuf
-dq6yqlLbwLEZWSJTJOBuIpnVcWq+7YFg0RtDyZK2/g==
+AcLBXAQAAQoABgUCZ5zT4QAKCRDgT5vottzAEsgCD/9q8pRsFTFf/2MO6D2+fVGUm/DV5JwQp1mU
+Tvg8SayQRgO42nvTi0dajwwJxqhrkwxB2Hhqf06XQNcxt9cmrBOeUDmXS9fjEDEfhD+isI6BQTRF
+ORhr7GpepMaq4uAQ5UTlHYULT8mlkAyY2pAl/NIQronVq1fgxv8rBAIV2yZo6AxT3cuj/kFPRHDU
+fT85SSyL5yUjt1+x9JM+1Nse/JML37oE1EFKCV2h6ahclDwEywlAkqk5+FQm5koHTrUIWdpxsOF6
+tUEM3yTV5Tb13/urpoa6f1HEAVpQycbHF6AGuYmGC+g+SxNnzAF+Tb5Bwj1RYGXoi03Ac8qZiIEV
+4s4odX8husCcz4P/brNjfXcN3X1x+Yu+50l16aIUv8amLUIfQAPOkMUmWvCE8Xfn/Bvt4nCdUWj7
+yqY7ZMe8qt4FqXbECvA9SpRxeTadaFIQ6tNuPgkw4S4UUJGtZ4oGKGxKCSGlNqO/viyq42K8KUO6
+uX08LIqbD2ZqFrHm+b+cKZ2uPQSjT8R4oAeEWpbqrK23KNpAGIX/TyQZt6eQr7rn69PthPMNTL6F
+Lt7ykPJRI0RmHUza741ACET/YyhXbFo95Gr5EFMNZPDIvtEdbEXB0o9cPyE849YRn43UiF7eZH3q
+FSFszRqpuxz0GL2xaGEU6jTbDDRckZqZFWqMtUHMEA==

--- a/ubuntu-core-desktop-24-amd64.json
+++ b/ubuntu-core-desktop-24-amd64.json
@@ -6,8 +6,8 @@
     "model": "ubuntu-core-desktop-24-amd64",
     "display-name":"Ubuntu Core Desktop 24 (amd64)",
     "architecture": "amd64",
-    "revision": "0",
-    "timestamp": "2024-07-04T10:33:44+08:00",
+    "revision": "1",
+    "timestamp": "2025-01-31T10:37:55+01:00",
     "grade": "signed",
     "storage-safety": "prefer-encrypted",
     "base": "core24-desktop",
@@ -126,6 +126,12 @@
             "default-channel": "latest/candidate",
             "type": "app",
             "id": "tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5"
+        },
+        {
+            "name": "pipewire",
+            "default-channel": "latest/candidate",
+            "type": "app",
+            "id": "cXXVv4NGwXqlxTVSdrjsuvrPGAHfRSRs"
         }
     ]
 }

--- a/ubuntu-core-desktop-24-amd64.model
+++ b/ubuntu-core-desktop-24-amd64.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 1
 series: 16
 brand-id: canonical
 model: ubuntu-core-desktop-24-amd64
@@ -104,17 +105,22 @@ snaps:
     id: tBdYpKjXcW5farGGJaWiYXrxIwMVMtx5
     name: ubuntu-desktop-init
     type: app
+  -
+    default-channel: latest/candidate
+    id: cXXVv4NGwXqlxTVSdrjsuvrPGAHfRSRs
+    name: pipewire
+    type: app
 storage-safety: prefer-encrypted
-timestamp: 2024-07-04T10:33:44+08:00
+timestamp: 2025-01-31T10:37:55+01:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZoYTygAKCRDgT5vottzAEnlLD/4toc4w5IiLm/xmBFL8BVwXXVQsvNNtVYaT
-NGSa+q7OJXeVbPQnnRMK4oH31IbGFngK3IHoc04LK76W2GQzAE4SQxTcV9VTlyPrVc6OeCn9rSWj
-zFX/fOVuD5Wd6OOgNitaHqVHh8CDQFcsdOBICImHG6s0Au1mIDVQvV/DxcnnprJ53yXFCeastuX+
-CnZiB6wOv/dzGHnIbhpUtKg5HV5jZoIkmplWAZr1IXd8gAPvltDzpJYwN6GMHK6SLUD1tgviP4ZB
-gw9IT11DCeB9TOEnsAs7y1YApUdkxMSv4B+Jwew/lkjysncULqFCt6fCD3HEw+OdULb/OrFnYcSV
-4NqPBop/9mi+CB5Fs3ubtlKxK9VnSJbLpXsyBeDvljVKp0MvNBpCTJnlGtRvQE/bHLpaAhRRsP0R
-6cUqd1ieRm4wp/1/v+zMjdp6VL7co0/a6jZgtfptCMnCC6Z0KdLWGQjaXDwxNStqMK3h/Au2YWDc
-ZgZ/+wTxMlDyU4i4gg+rByV2yPHfGeVpN7D7nuY8OWXq1ezESY6K5fsOW77/XEjZJOI3BFOJ6Xnl
-2ATKBs6uSmMPQSZo21sk+E0c2gH8qj6L6mUcAz2qvilur9w4uEM3TRfZcAKPN+8lV44eB8/aZpq7
-GfjsXFa+DpXJzWdC91SP4yIeojoj3OAl4gNwt0c85g==
+AcLBXAQAAQoABgUCZ5zT4gAKCRDgT5vottzAEoUTEACPVVlhQG7XeS64fULTqFEOwbtpXQbzOSha
+cA75LkAwEGns3704ca09nJObeTVdg5KTiWheZ8Es123GZ0ywGsdoVHNOYcxpXahDTQjBG5+W7tWZ
+A+RS8y4VrqWRzUrNP0B0rpV6Z3LMVj0ClRPmczSpE3S4XWgHCPINBbf4nmJpnR2nAUgIVargSwIk
+Fdhq+hZyqF3WrITk5sqqbJC7byoTqFYltF2g4NnwXPymagPjByjRpRxAzzax8Ya/HRPzoOhRXSKn
+1KRonNj1INYQ26JuVv+NXQMk5GZp5gjN+yhxWSqenfFjjcRHJKM5I//F1X+k7VrufJTIXhvlQnqe
+tElTsCDj1mzs3g2VPsocgdVD0oZxrpABDa25j4hsavPBGkxD2zyDrt6cTmHE9sPb1CMibfRpJsLQ
+NV7MZfgyA7AvZvVysXhBkqZL/xxxP3g3dVz4dvLFIMXs49rMBD4QqI9Nc70fosIUcwPtrEyuOamH
+VN2aMXvK19fMGNRTOds8HERB4es4aELUTDufOUiyBsKemniL1mu4HasadTYJesCv8P/7lXYjz2bz
+5qkA9pM4N5/WrDk4GcRFeIXJSIbEmWeuIEZM8+xyYQqp7oaD6sCUXjov0mPij82IFPgSZH/n9Ei1
+9i+vQJacHNHBfIbO3Jvr/GFe1xC9kwRPFAw6G6t4Xw==


### PR DESCRIPTION
This patch adds pipewire to the JSONs, but still require them to be signed by canonical to generate the final .model files. Along with https://github.com/canonical/core-base-desktop/pull/74 should allow to use pipewire snap in core desktop directly.